### PR TITLE
Fix crash when TMPHexEditor is used inside a frame.

### DIFF
--- a/src/mphexeditor.pas
+++ b/src/mphexeditor.pas
@@ -998,6 +998,7 @@ type
     // @exclude(used by TMPHexEditorEx for internal undo changing)
     FModified: boolean;
 
+    procedure CreateHandle; override;
     procedure MoveColRow(ACol, ARow: Longint;MoveAnchor, Show: Boolean);
 
     // @exclude(overwrite mouse wheel for zooming)
@@ -3148,6 +3149,10 @@ end;
 
 procedure TCustomMPHexEditor.CreateEmptyFile(const TempName: string);
 begin
+  // Avoid crash when HexEditor is contained in a TFrame.
+  if not HandleAllocated then
+    exit;
+
   FreeStorage;
   if TempName = '' then
     FFileName := UNNAMED_FILE
@@ -3162,6 +3167,12 @@ begin
   FHasFile := False;
   MoveColRow(GRID_FIXED, GRID_FIXED, True, True);
   Changed;
+end;
+
+procedure TCustomMPHexEditor.CreateHandle;
+begin
+  inherited;
+  CreateEmptyFile(UNNAMED_FILE);
 end;
 
 procedure TCustomMPHexEditor.SaveToStream(Strm: TStream);


### PR DESCRIPTION
When the HexEditor is inserted into a TFrame at designtime not yet used in a TForm, and that project is reloaded later, the IDE crashes with a no parent error.  The same crash occurs at runtime when that frame is inserted into a form.

This is caused by the method CreateEmptyFile which is called in Loaded when the frame does not yet have a parent in this scenario. Calling CreateEmptyFile in the overridden CreateHandle fixes the issue.

Attaching a test project.
[MPHexEditor_in_Frame_Crash.zip](https://github.com/michalgw/mphexeditor/files/3554989/MPHexEditor_in_Frame_Crash.zip)
